### PR TITLE
Added mutate option for promisify all

### DIFF
--- a/src/promisify.js
+++ b/src/promisify.js
@@ -31,8 +31,9 @@ module.exports.all = (cbModule, options = {}) => {
     return cbModule;
   }
 
-  const async = Object.assign({}, cbModule);
   options.suffix = options.suffix || 'Async';
+  options.mutate = typeof options.mutate === 'boolean' ? options.mutate : false;
+  const async = options.mutate ? cbModule : Object.assign({}, cbModule);
 
   Object.keys(cbModule).forEach((key) => {
     if (shouldInclude(key, cbModule, options.exclude, options.include)) {

--- a/test/promisify.spec.js
+++ b/test/promisify.spec.js
@@ -133,6 +133,22 @@ describe('promisify', () => {
       .then(() => done());
   });
 
+  it('Should promisify all and not mutate the module', () => {
+    const asyncModule = promisify.all(mdl);
+    expect(mdl).to.not.have.any.keys('successAsync', 'errorAsync', 'thirdAsync');
+    expect(asyncModule).to.have.all.keys(
+      'name', 'success', 'error', 'third', 'successAsync', 'errorAsync', 'thirdAsync'
+    );
+  });
+
+  it('Should promisify all and mutate the module ', () => {
+    const asyncModule = promisify.all(mdl, { mutate: true });
+    expect(asyncModule).to.deep.equal(mdl);
+    expect(mdl).to.have.all.keys(
+      'name', 'success', 'error', 'third', 'successAsync', 'errorAsync', 'thirdAsync'
+    );
+  });
+
   it('Should promise all except excluded functions', () => {
     const asyncModule = promisify.all(mdl, { exclude: ['error', 'third'] });
     expect('successAsync' in asyncModule).to.equal(true);


### PR DESCRIPTION
Promisify all now accepts mutate option which determines if target module will be mutated. Default value is false to compatible with current behavior.