### PR TITLE
Issue#33

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,20 +371,6 @@ Recursively apply [Object.freeze](https://developer.mozilla.org/en-US/docs/Web/J
   Object.isFrozen(person.address); // true WE HE
 ```
 
-By default deepFreeze do not loop over prototype chain.
-That behaviour can be overridden by providing { proto: true } option.
-
-```javascript
-  const ob1 = { test: { a: 'a' } };
-  const ob2 = Object.create(ob1);
-
-  deepFreeze(ob2);
-  Object.isFrozen(ob2.test); // false - because test property is on ob2 prototype
-
-  deepFreeze(ob2, { proto: true });
-  Object.isFrozen(ob2.test); // true
-```
-
 
 ### deepSeal
 

--- a/src/deepFreeze.js
+++ b/src/deepFreeze.js
@@ -2,4 +2,4 @@ const deep = require('./internals/deep');
 
 // Public
 
-module.exports = (obj, options) => deep('freeze', obj, options);
+module.exports = (obj) => deep('freeze', obj);

--- a/src/deepPreventExtensions.js
+++ b/src/deepPreventExtensions.js
@@ -2,4 +2,4 @@ const deep = require('./internals/deep');
 
 // Public
 
-module.exports = (obj, options) => deep('preventExtensions', obj, options);
+module.exports = (obj) => deep('preventExtensions', obj);

--- a/src/deepSeal.js
+++ b/src/deepSeal.js
@@ -2,4 +2,4 @@ const deep = require('./internals/deep');
 
 // Public
 
-module.exports = (obj, options) => deep('seal', obj, options);
+module.exports = (obj) => deep('seal', obj);

--- a/src/internals/deep.js
+++ b/src/internals/deep.js
@@ -11,7 +11,7 @@ const isApplied = {
 module.exports = function deep(action, obj) {
   Object[action](obj);
 
-  Object.getOwnPropertyNames( obj ).forEach(( key ) => {
+  Object.getOwnPropertyNames(obj).forEach((key) => {
     const prop = obj !== Function.prototype && obj[key]; // Function.prototype is used to prevent following error on function prototype => TypeError: 'caller' and 'arguments' are restricted function properties and cannot be accessed in this context
     if (prop &&
       (typeof prop === 'object' || typeof prop === 'function') &&

--- a/src/internals/deep.js
+++ b/src/internals/deep.js
@@ -8,19 +8,17 @@ const isApplied = {
 
 // Public
 
-module.exports = function deep(action, obj, options) {
-  options = options || {};
+module.exports = function deep(action, obj) {
   Object[action](obj);
 
-  for (const key in obj) {
-    const prop = obj[key];
+  Object.getOwnPropertyNames( obj ).forEach(( key ) => {
+    const prop = obj !== Function.prototype && obj[key]; // Function.prototype is used to prevent following error on function prototype => TypeError: 'caller' and 'arguments' are restricted function properties and cannot be accessed in this context
     if (prop &&
       (typeof prop === 'object' || typeof prop === 'function') &&
-      !isApplied[action](prop) &&
-      (options.proto || Object.prototype.hasOwnProperty.call(obj, key))) {
-      deep(action, prop, options);
+      !isApplied[action](prop)) {
+      deep(action, prop);
     }
-  }
+  });
 
   return obj;
 };

--- a/test/collar.spec.js
+++ b/test/collar.spec.js
@@ -19,7 +19,7 @@ describe('collar', () => {
     collar(Promise.all([
       new Promise((resolve) => setTimeout(resolve, 1, '1')),
       new Promise((resolve) => setTimeout(resolve, 3, '2'))
-    ]), 5)
+    ]), 15)
       .then(([first, second]) => {
         expect(first).to.equal('1');
         expect(second).to.equal('2');

--- a/test/deep.spec.js
+++ b/test/deep.spec.js
@@ -60,13 +60,11 @@ describe('deep', () => {
       expect(Object.isFrozen(obj)).to.equal(true);
     });
 
-    it('Should freeze prototype chain', () => {
-      deepFreeze(proto, { proto: true });
-      expect(Object.isFrozen(proto)).to.equal(true);
-      expect(Object.isFrozen(proto.child)).to.equal(true);
-      expect(Object.isFrozen(proto.ob2Prop)).to.equal(true);
-      expect(Object.isFrozen(proto.proto)).to.equal(true);
-      expect(Object.isFrozen(proto.proto.test)).to.equal(true);
+    it('Should not brake on restricted properties', () => {
+      const fun = function() { };
+      const funPrototype = Object.getPrototypeOf(fun);
+      deepFreeze(funPrototype);
+      expect(Object.isFrozen(funPrototype)).to.equal(true);
     });
 
     it('Should deep freeze object with null prototype', () => {
@@ -100,6 +98,16 @@ describe('deep', () => {
       expect(Object.isFrozen(ob.set.test)).to.equal(true);
     });
 
+    it('Should deep freeze non enumerable properties', () => {
+      Object.defineProperty(obj, 'nonEnumerable', {
+        enumerable: false,
+        value: {}
+      });
+
+      deepFreeze(obj);
+      expect(Object.isFrozen(obj.nonEnumerable)).to.equal(true);
+    });
+
     it('Should validate readme examples', () => {
       const person = {
         fullName: 'test person',
@@ -117,15 +125,6 @@ describe('deep', () => {
       deepFreeze(person);
       expect(Object.isFrozen(person)).to.equal(true);
       expect(Object.isFrozen(person.address)).to.equal(true);
-
-      const ob1 = { test: { a: 'a' } };
-      const ob2 = Object.create(ob1);
-
-      deepFreeze(ob2);
-      expect(Object.isFrozen(ob2.test)).to.equal(false);
-
-      deepFreeze(ob2, { proto: true });
-      expect(Object.isFrozen(ob2.test)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
* deepFreeze of non enumerable properties. This fixes #33 
* Remove option to deepFreeze prototype chain. DeepFreezing of prototype chain leads to unexpected behavior as it's always goes to built in objects like Function, Array, Object, Date etc....