### PR TITLE
Freeze prototype chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,25 @@ Recursively apply [Object.freeze](https://developer.mozilla.org/en-US/docs/Web/J
   Object.isFrozen(person.address); // true WE HE
 ```
 
+By default deepFreeze do not loop over prototype chain.
+That behaviour can be overridden by providing ```{ proto: true }``` option.
+Providing this option will freeze only user defined prototypes while leaving default built in prototypes unmodified.
+
+```javascript
+  const ob1 = { test: { a: 'a' } };
+  const ob2 = Object.create(ob1);
+
+  deepFreeze(ob2);
+  Object.isFrozen(ob2.test); // false - because test property is on ob2 prototype
+
+  deepFreeze(ob2, { proto: true });
+
+  Object.isFrozen(ob2.test); // true
+  Object.isFrozen(Object.getPrototypeOf(ob2)); // true
+  Object.isFrozen(ob1); // true - same as writing above statement
+  Object.isFrozen(Object.getPrototypeOf(ob1)); // false - prototype of ob1 is default built in object so it's skipped
+```
+
 
 ### deepSeal
 

--- a/dist/deepFreeze.js
+++ b/dist/deepFreeze.js
@@ -2,4 +2,12 @@ const deep = require('./internals/deep');
 
 // Public
 
+/**
+ * Recursively apply Object.freeze on an object and all of the object properties that are either object or function.
+ *
+ * @param {Object} obj - The object we want to freeze
+ * @param {Object} [options]
+ * @param {boolean} [options.proto=false] - Should we loop over prototype chain or not
+ * @returns {Object} Returns initial object with applied Object.freeze
+ */
 module.exports = (obj) => deep('freeze', obj);

--- a/src/deepFreeze.js
+++ b/src/deepFreeze.js
@@ -2,4 +2,4 @@ const deep = require('./internals/deep');
 
 // Public
 
-module.exports = (obj) => deep('freeze', obj);
+module.exports = (obj, options) => deep('freeze', obj, options);

--- a/src/deepPreventExtensions.js
+++ b/src/deepPreventExtensions.js
@@ -2,4 +2,4 @@ const deep = require('./internals/deep');
 
 // Public
 
-module.exports = (obj) => deep('preventExtensions', obj);
+module.exports = (obj, options) => deep('preventExtensions', obj, options);

--- a/src/deepPreventExtensions.js
+++ b/src/deepPreventExtensions.js
@@ -2,4 +2,12 @@ const deep = require('./internals/deep');
 
 // Public
 
+/**
+ * Recursively apply Object.preventExtensions on an object and all of the object properties that are either object or function.
+ *
+ * @param {Object} obj - The object we want to freeze
+ * @param {Object} [options]
+ * @param {boolean} [options.proto=false] - Should we loop over prototype chain or not
+ * @returns {Object} Returns initial object with applied Object.preventExtensions
+ */
 module.exports = (obj, options) => deep('preventExtensions', obj, options);

--- a/src/deepSeal.js
+++ b/src/deepSeal.js
@@ -2,4 +2,4 @@ const deep = require('./internals/deep');
 
 // Public
 
-module.exports = (obj) => deep('seal', obj);
+module.exports = (obj, options) => deep('seal', obj, options);

--- a/src/deepSeal.js
+++ b/src/deepSeal.js
@@ -2,4 +2,12 @@ const deep = require('./internals/deep');
 
 // Public
 
+/**
+ * Recursively apply Object.seal on an object and all of the object properties that are either object or function.
+ *
+ * @param {Object} obj - The object we want to seal
+ * @param {Object} [options]
+ * @param {boolean} [options.proto=false] - Should we loop over prototype chain or not
+ * @returns {Object} Returns initial object with applied Object.seal
+ */
 module.exports = (obj, options) => deep('seal', obj, options);

--- a/src/internals/deep.js
+++ b/src/internals/deep.js
@@ -28,7 +28,7 @@ module.exports = function deep(action, obj, options, processed = new Set()) {
     });
   }
 
-  // Freeze object prototype is specified
+  // Freeze object prototype if specified
   if (options && typeof options === 'object' && options.proto) {
     const proto = Object.getPrototypeOf(obj);
     !isNativeObject(proto) && deep(action, proto, options, processed);

--- a/src/internals/deep.js
+++ b/src/internals/deep.js
@@ -2,6 +2,16 @@ const isNativeObject = require('./isNativeObject');
 
 // Public
 
+/**
+ * Recursively apply provided operation on object and all of the object properties that are either object or function.
+ *
+ * @param {string='freeze', 'seal', 'preventExtensions'} action - The action to be applied on object and his properties
+ * @param {Object} obj - The object we want to modify
+ * @param {Object} [options]
+ * @param {boolean} [options.proto=false] - Should we loop over prototype chain or not
+ * @param {Set} [processed=new Set()] - Used internally to prevent circular references
+ * @returns {Object} Returns initial object which now have applied actions on him
+ */
 module.exports = function deep(action, obj, options, processed = new Set()) {
   Object[action](obj);
 

--- a/src/internals/deep.js
+++ b/src/internals/deep.js
@@ -12,7 +12,7 @@ module.exports = function deep(action, obj, options, processed = new Set()) {
       const prop = obj[key];
       if (prop &&
         (typeof prop === 'object' || typeof prop === 'function') &&
-        !ArrayBuffer.isView(prop) && !processed.has(prop)) { // Prevent issue with freezing buffer
+        !ArrayBuffer.isView(prop) && !processed.has(prop)) { // Prevent issue with freezing buffers
         deep(action, prop, options, processed);
       }
     });

--- a/src/internals/isNativeObject.js
+++ b/src/internals/isNativeObject.js
@@ -2,7 +2,7 @@
 
 /**
  * A way to detect if object is native or user defined
- * Warning! Detection is not bulletproof and can be easily tricked (on purpose).
+ * Warning! Detection is not bulletproof and can be easily tricked.
  * In real word scenarios there should not be fake positives
  *
  * @param {any} obj - preform isNativeObject check on provided value

--- a/src/internals/isNativeObject.js
+++ b/src/internals/isNativeObject.js
@@ -10,8 +10,8 @@
  *
  * @example
  * isNativeObject({}); \\ => false
- * isNativeObject(Object); \\ => true
- * isNativeObject(Number); \\ => true
+ * isNativeObject(Object.prototype); \\ => true
+ * isNativeObject(Number.prototype); \\ => true
  */
 module.exports = function(obj) {
   return !!(obj &&

--- a/src/internals/isNativeObject.js
+++ b/src/internals/isNativeObject.js
@@ -1,0 +1,22 @@
+// Public
+
+/**
+ * A way to detect if object is native or user defined
+ * Warning! Detection is not bulletproof and can be easily tricked (on purpose).
+ * In real word scenarios there should not be fake positives
+ *
+ * @param {any} obj - preform isNativeObject check on provided value
+ * @returns {boolean} - true if object is native false otherwise
+ *
+ * @example
+ * isNativeObject({}); \\ => false
+ * isNativeObject(Object); \\ => true
+ * isNativeObject(Number); \\ => true
+ */
+module.exports = function(obj) {
+  return !!(obj &&
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    Object.prototype.hasOwnProperty.call(obj, 'constructor') &&
+    typeof obj.constructor === 'function' &&
+    Function.prototype.toString.call(obj.constructor).includes('[native code]'));
+};

--- a/test/config/mocha.opts
+++ b/test/config/mocha.opts
@@ -1,3 +1,3 @@
 --reporter spec
-test/*.spec.js
+test/unit/**/*.spec.js
 --recursive

--- a/test/unit/collar.spec.js
+++ b/test/unit/collar.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const collar = require('../src/collar');
+const collar = require('../../src/collar');
 
 
 const shouldNotBeCalled = () => { throw Error('This should not be called'); };

--- a/test/unit/deep.spec.js
+++ b/test/unit/deep.spec.js
@@ -1,8 +1,8 @@
 const { expect } = require('chai');
 
-const deepFreeze = require('../src/deepFreeze');
-const deepSeal = require('../src/deepSeal');
-const deepPreventExtensions = require('../src/deepPreventExtensions');
+const deepFreeze = require('../../src/deepFreeze');
+const deepSeal = require('../../src/deepSeal');
+const deepPreventExtensions = require('../../src/deepPreventExtensions');
 
 describe('deep', () => {
   let obj;

--- a/test/unit/deep.spec.js
+++ b/test/unit/deep.spec.js
@@ -125,6 +125,16 @@ describe('deep', () => {
       deepFreeze(person);
       expect(Object.isFrozen(person)).to.equal(true);
       expect(Object.isFrozen(person.address)).to.equal(true);
+
+      const ob1 = { test: { a: 'a' } };
+      const ob2 = Object.create(ob1);
+
+      deepFreeze(ob2, { proto: true });
+
+      expect(Object.isFrozen(ob2.test)).to.equal(true);
+      expect(Object.isFrozen(Object.getPrototypeOf(ob2))).to.equal(true);
+      expect(Object.isFrozen(ob1)).to.equal(true);
+      expect(Object.isFrozen(Object.getPrototypeOf(ob1))).to.equal(false);
     });
 
     it('Should freeze object with Symbol property', () => {

--- a/test/unit/deep.spec.js
+++ b/test/unit/deep.spec.js
@@ -152,6 +152,24 @@ describe('deep', () => {
       expect(Object.isFrozen(obj.first.second)).to.equal(true);
       expect(Object.isFrozen(obj.first.second.third)).to.equal(true);
     });
+
+    it('Should not freeze object prototype', () => {
+      deepFreeze(proto);
+      expect(Object.isFrozen(proto)).to.equal(true);
+      expect(Object.isFrozen(Object.getPrototypeOf(proto))).to.equal(false);
+    });
+
+    it('Should freeze object prototype', () => {
+      deepFreeze(proto, { proto: true });
+      const proto1 = Object.getPrototypeOf(proto);
+      const proto2 = Object.getPrototypeOf(proto1);
+      const nativeProto = Object.getPrototypeOf(proto2);
+
+      expect(Object.isFrozen(proto)).to.equal(true);
+      expect(Object.isFrozen(proto1)).to.equal(true);
+      expect(Object.isFrozen(proto2)).to.equal(true);
+      expect(Object.isFrozen(nativeProto)).to.equal(false);
+    });
   });
 
 

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const jsFlock = require('../src/index');
+const jsFlock = require('../../src/index');
 
 
 describe('index', () => {

--- a/test/unit/internals/isNativeObject.spec.js
+++ b/test/unit/internals/isNativeObject.spec.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+
+const isNativeObject = require('../../../src/internals/isNativeObject');
+
+describe.only('isNativeObject', () => {
+  it('Should return false for non objects', () => {
+    expect(isNativeObject(null)).to.equal(false);
+    expect(isNativeObject(undefined)).to.equal(false);
+    expect(isNativeObject(33)).to.equal(false);
+    expect(isNativeObject('test')).to.equal(false);
+  });
+
+  it('Should return false for user defined objects', () => {
+    const a = {};
+    const b = Object.create(a);
+
+    expect(isNativeObject(a)).to.equal(false);
+    expect(isNativeObject(a)).to.equal(false);
+    expect(isNativeObject(b)).to.equal(false);
+    expect(isNativeObject(Object.getPrototypeOf(b))).to.equal(false);
+    expect(isNativeObject(new Set([1, 2, 4]))).to.equal(false);
+    expect(isNativeObject([])).to.equal(false);
+    expect(isNativeObject(String('Sta je ovo'))).to.equal(false);
+  });
+
+  it.only('Should return true for native objects', () => {
+    expect(isNativeObject(Object.prototype)).to.equal(true);
+    expect(isNativeObject(Number.prototype)).to.equal(true);
+    expect(isNativeObject(Array.prototype)).to.equal(true);
+    expect(isNativeObject(Function.prototype)).to.equal(true);
+    expect(isNativeObject(Set.prototype)).to.equal(true);
+
+    expect(isNativeObject(Object.getPrototypeOf({}))).to.equal(true);
+    expect(isNativeObject(Object.getPrototypeOf(String('ala')))).to.equal(true);
+    expect(isNativeObject(Object.getPrototypeOf(Number(33)))).to.equal(true);
+  });
+});

--- a/test/unit/internals/isNativeObject.spec.js
+++ b/test/unit/internals/isNativeObject.spec.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 
 const isNativeObject = require('../../../src/internals/isNativeObject');
 
-describe.only('isNativeObject', () => {
+describe('isNativeObject', () => {
   it('Should return false for non objects', () => {
     expect(isNativeObject(null)).to.equal(false);
     expect(isNativeObject(undefined)).to.equal(false);
@@ -23,7 +23,7 @@ describe.only('isNativeObject', () => {
     expect(isNativeObject(String('Sta je ovo'))).to.equal(false);
   });
 
-  it.only('Should return true for native objects', () => {
+  it('Should return true for native objects', () => {
     expect(isNativeObject(Object.prototype)).to.equal(true);
     expect(isNativeObject(Number.prototype)).to.equal(true);
     expect(isNativeObject(Array.prototype)).to.equal(true);

--- a/test/unit/last.spec.js
+++ b/test/unit/last.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const last = require('../src/last');
+const last = require('../../src/last');
 
 
 describe('last', () => {

--- a/test/unit/promisify.spec.js
+++ b/test/unit/promisify.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const promisify = require('../src/promisify');
+const promisify = require('../../src/promisify');
 
 
 const shouldNotBeCalled = () => {

--- a/test/unit/singular.spec.js
+++ b/test/unit/singular.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const singular = require('../src/singular');
+const singular = require('../../src/singular');
 
 
 describe('singular', () => {

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const sort = require('../src/sort');
+const sort = require('../../src/sort');
 
 
 describe('sort', () => {

--- a/test/unit/toEnum.spec.js
+++ b/test/unit/toEnum.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const toEnum = require('../src/toEnum');
+const toEnum = require('../../src/toEnum');
 
 
 describe('toEnum', () => {

--- a/test/unit/waitFor.spec.js
+++ b/test/unit/waitFor.spec.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const waitFor = require('../src/waitFor');
+const waitFor = require('../../src/waitFor');
 
 
 describe('waitFor', () => {


### PR DESCRIPTION
Allow deepFreez, deepSeal or deepPreventExtensions of prototype chain. 

Operation stops with execution after code reaches native prototype (without applying operation on native prototype)