### PR TITLE
Add comparer option to by() syntax

### DIFF
--- a/src/sort.js
+++ b/src/sort.js
@@ -55,7 +55,6 @@ const multiPropStringSorter = function(sortBy, thenBy, depth, direction, compare
  * @example sort(users).asc(['firstName', 'lastName'])
  */
 const multiPropObjectSorter = function(sortByObj, thenBy, depth, _direction, _comparer, a, b) {
-
   const sortBy = sortByObj.asc || sortByObj.desc;
   const direction = sortByObj.asc ? 1 : -1;
   const comparer = sortByObj.comparer ? compareSorter(sortByObj.comparer) : sorter;
@@ -120,7 +119,7 @@ const sort = function(direction, ctx, sortBy, comparer) {
     _sorter = functionSorter.bind(undefined, direction, sortBy, comparer);
   } else {
     _sorter = getMultiPropertySorter(sortBy[0])
-    .bind(undefined, sortBy.shift(), sortBy, 0, direction, comparer);
+      .bind(undefined, sortBy.shift(), sortBy, 0, direction, comparer);
   }
 
   return ctx.sort(_sorter);

--- a/src/sort.js
+++ b/src/sort.js
@@ -29,6 +29,13 @@ const functionSorter = function(direction, sortBy, a, b) {
 };
 
 /**
+ * @example sort(users).asc(new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});y)
+ */
+const collatorSorter = function(direction, collator, a, b) {
+  return collator.compare(a, b) * direction;
+};
+
+/**
  * Used when we have sorting by multyple properties and when current sorter is function
  * @example sort(users).asc([p => p.address.city, p => p.firstName])
  */
@@ -109,6 +116,8 @@ const sort = function(direction, ctx, sortBy) {
     _sorter = stringSorter.bind(undefined, direction, sortBy);
   } else if (typeof sortBy === 'function') {
     _sorter = functionSorter.bind(undefined, direction, sortBy);
+  } else if (typeof sortBy === 'object' && Intl && sortBy instanceof Intl.Collator) {
+    _sorter = collatorSorter.bind(undefined, direction, sortBy);
   } else {
     _sorter = getMultiPropertySorter(sortBy[0])
       .bind(undefined, sortBy.shift(), sortBy, 0, direction);

--- a/src/sort.js
+++ b/src/sort.js
@@ -2,7 +2,7 @@
 
 // >>> SORTERS <<<
 
-const sorter = function(direction, a, b) {
+const defaultComparer = function(direction, a, b) {
   if (a === b) return 0;
   if (a < b) return -direction;
   if (a == null) return 1;
@@ -11,7 +11,7 @@ const sorter = function(direction, a, b) {
   return direction;
 };
 
-const compareSorter = function(comparer) {
+const customComparerProvider = function(comparer) {
   return function(direction, a, b) {
     return comparer(a, b) * direction;
   };
@@ -57,7 +57,7 @@ const multiPropStringSorter = function(sortBy, thenBy, depth, direction, compare
 const multiPropObjectSorter = function(sortByObj, thenBy, depth, _direction, _comparer, a, b) {
   const sortBy = sortByObj.asc || sortByObj.desc;
   const direction = sortByObj.asc ? 1 : -1;
-  const comparer = sortByObj.comparer ? compareSorter(sortByObj.comparer) : sorter;
+  const comparer = sortByObj.comparer ? customComparerProvider(sortByObj.comparer) : defaultComparer;
 
 
   if (!sortBy) {
@@ -129,8 +129,8 @@ const sort = function(direction, ctx, sortBy, comparer) {
 
 module.exports = function(ctx) {
   return {
-    asc: (sortBy) => sort(1, ctx, sortBy, sorter),
-    desc: (sortBy) => sort(-1, ctx, sortBy, sorter),
+    asc: (sortBy) => sort(1, ctx, sortBy, defaultComparer),
+    desc: (sortBy) => sort(-1, ctx, sortBy, defaultComparer),
     by: (sortBy) => {
       if (!Array.isArray(ctx)) return ctx;
 
@@ -143,7 +143,7 @@ module.exports = function(ctx) {
       if (sortBy.length === 1) {
         const direction = sortBy[0].asc ? 1 : -1;
         const sortOnProp = sortBy[0].asc || sortBy[0].desc;
-        const comparer = sortBy[0].comparer ? compareSorter(sortBy[0].comparer) : sorter;
+        const comparer = sortBy[0].comparer ? customComparerProvider(sortBy[0].comparer) : defaultComparer;
         if (!sortOnProp) {
           throw Error(`sort: Invalid 'by' sorting configuration.
             Expecting object with 'asc' or 'desc' key`);

--- a/src/sort.js
+++ b/src/sort.js
@@ -38,25 +38,28 @@ const functionSorter = function(direction, sortBy, comparer, a, b) {
  * Used when we have sorting by multyple properties and when current sorter is function
  * @example sort(users).asc([p => p.address.city, p => p.firstName])
  */
-const multiPropFunctionSorter = function(sortBy, thenBy, depth, direction, a, b) {
-  return multiPropEqualityHandler(sortBy(a), sortBy(b), thenBy, depth, direction, a, b);
+const multiPropFunctionSorter = function(sortBy, thenBy, depth, direction, comparer, a, b) {
+  return multiPropEqualityHandler(sortBy(a), sortBy(b), thenBy, depth, direction, comparer, a, b);
 };
 
 /**
  * Used when we have sorting by multiple properties and when current sorter is string
  * @example sort(users).asc(['firstName', 'lastName'])
  */
-const multiPropStringSorter = function(sortBy, thenBy, depth, direction, a, b) {
-  return multiPropEqualityHandler(a[sortBy], b[sortBy], thenBy, depth, direction, a, b);
+const multiPropStringSorter = function(sortBy, thenBy, depth, direction, comparer, a, b) {
+  return multiPropEqualityHandler(a[sortBy], b[sortBy], thenBy, depth, direction, comparer, a, b);
 };
 
 /**
  * Used with 'by' sorter when we have sorting in multiple direction
  * @example sort(users).asc(['firstName', 'lastName'])
  */
-const multiPropObjectSorter = function(sortByObj, thenBy, depth, _direction, a, b) {
+const multiPropObjectSorter = function(sortByObj, thenBy, depth, _direction, _comparer, a, b) {
+
   const sortBy = sortByObj.asc || sortByObj.desc;
   const direction = sortByObj.asc ? 1 : -1;
+  const comparer = sortByObj.comparer ? compareSorter(sortByObj.comparer) : sorter;
+
 
   if (!sortBy) {
     throw Error(`sort: Invalid 'by' sorting configuration.
@@ -64,7 +67,7 @@ const multiPropObjectSorter = function(sortByObj, thenBy, depth, _direction, a, 
   }
 
   const multiSorter = getMultiPropertySorter(sortBy);
-  return multiSorter(sortBy, thenBy, depth, direction, a, b);
+  return multiSorter(sortBy, thenBy, depth, direction, comparer, a, b);
 };
 
 // >>> HELPERS <<<
@@ -84,16 +87,16 @@ const getMultiPropertySorter = function(sortBy) {
   return multiPropObjectSorter;
 };
 
-const multiPropEqualityHandler = function(valA, valB, thenBy, depth, direction, a, b) {
+const multiPropEqualityHandler = function(valA, valB, thenBy, depth, direction, comparer, a, b) {
   if (valA === valB || (valA == null && valB == null)) {
     if (thenBy.length > depth) {
       const multiSorter = getMultiPropertySorter(thenBy[depth]);
-      return multiSorter(thenBy[depth], thenBy, depth + 1, direction, a, b);
+      return multiSorter(thenBy[depth], thenBy, depth + 1, direction, comparer, a, b);
     }
     return 0;
   }
 
-  return sorter(direction, valA, valB);
+  return comparer(direction, valA, valB);
 };
 
 /**
@@ -117,7 +120,7 @@ const sort = function(direction, ctx, sortBy, comparer) {
     _sorter = functionSorter.bind(undefined, direction, sortBy, comparer);
   } else {
     _sorter = getMultiPropertySorter(sortBy[0])
-    .bind(undefined, sortBy.shift(), sortBy, 0, direction);
+    .bind(undefined, sortBy.shift(), sortBy, 0, direction, comparer);
   }
 
   return ctx.sort(_sorter);
@@ -141,14 +144,15 @@ module.exports = function(ctx) {
       if (sortBy.length === 1) {
         const direction = sortBy[0].asc ? 1 : -1;
         const sortOnProp = sortBy[0].asc || sortBy[0].desc;
+        const comparer = sortBy[0].comparer ? compareSorter(sortBy[0].comparer) : sorter;
         if (!sortOnProp) {
           throw Error(`sort: Invalid 'by' sorting configuration.
             Expecting object with 'asc' or 'desc' key`);
         }
-        return sort(direction, ctx, sortOnProp, sortBy[0].comparer ? compareSorter(sortBy[0].comparer) : sorter);
+        return sort(direction, ctx, sortOnProp, comparer);
       }
 
-      const _sorter = multiPropObjectSorter.bind(undefined, sortBy.shift(), sortBy, 0, undefined);
+      const _sorter = multiPropObjectSorter.bind(undefined, sortBy.shift(), sortBy, 0, undefined, undefined);
       return ctx.sort(_sorter);
     }
   };

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -20,40 +20,42 @@ describe('sort', () => {
     persons = [{
       name: 'last',
       dob: new Date(1987, 14, 11),
-      address: { code: 3 },
-      unit: 'A10'
+      address: { code: 3 }
     }, {
       name: 'FIRST',
       dob: new Date(1987, 14, 9),
-      address: {},
-      unit: 'B10'
+      address: {}
     }, {
       name: 'In the middle',
       dob: new Date(1987, 14, 10),
-      address: { code: 1 },
-      unit: 'A1'
+      address: { code: 1 }
     }];
 
     multiPropArray = [{
       name: 'aa',
       lastName: 'aa',
-      age: 10
+      age: 10,
+      unit: 'A10'
     }, {
       name: 'aa',
       lastName: undefined,
-      age: 8
+      age: 8,
+      unit: 'A1'
     }, {
       name: 'aa',
       lastName: null,
-      age: 9
+      age: 9,
+      unit: 'A01'
     }, {
       name: 'aa',
       lastName: 'bb',
-      age: 11
+      age: 11,
+      unit: 'C2'
     }, {
       name: 'bb',
       lastName: 'aa',
-      age: 6
+      age: 6,
+      unit: 'B3'
     }];
   });
 
@@ -213,14 +215,12 @@ describe('sort', () => {
     );
   });
 
-  it('Should sort object using a comparer', () => {
-    sort(persons).by([
+  it('Should sort object using multiple sorts and a comparer', () => {
+    sort(multiPropArray).by([
+      { desc: p => p.name },
       { asc: p => p.unit, comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare }
     ]);
 
-    assertOrder(
-      ['A1', 'A10', 'B10'],
-      idx => persons[idx].unit,
-    );
+    assertOrder([6, 8, 9, 10, 11], idx => multiPropArray[idx].age);
   });
 });

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -206,7 +206,7 @@ describe('sort', () => {
 
   it('Should sort flat array using a comparer', () => {
     sort(flatNaturalArray).by([
-      { asc: o=>o, comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare }
+      { asc: o => o, comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare }
     ]);
 
     assertOrder(

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -215,6 +215,14 @@ describe('sort', () => {
     );
   });
 
+  it('Should sort object using single sort with a comparer', () => {
+    sort(multiPropArray).by([
+      { asc: p => p.unit, comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare }
+    ]);
+
+    assertOrder(['A1', 'A01', 'A10', 'B3', 'C2'], idx => multiPropArray[idx].unit);
+  });
+
   it('Should sort object using multiple sorts and a comparer', () => {
     sort(multiPropArray).by([
       { desc: p => p.name },

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -20,15 +20,18 @@ describe('sort', () => {
     persons = [{
       name: 'last',
       dob: new Date(1987, 14, 11),
-      address: { code: 3 }
+      address: { code: 3 },
+      unit: 'A10'
     }, {
       name: 'FIRST',
       dob: new Date(1987, 14, 9),
-      address: {}
+      address: {},
+      unit: 'B10'
     }, {
       name: 'In the middle',
       dob: new Date(1987, 14, 10),
-      address: { code: 1 }
+      address: { code: 1 },
+      unit: 'A1'
     }];
 
     multiPropArray = [{
@@ -168,13 +171,13 @@ describe('sort', () => {
 
   it('Should throw invalid usage of by sorter exception', () => {
     expect(() => sort(multiPropArray).by('name'))
-      .to.throw(Error);
+    .to.throw(Error);
 
     expect(() => sort(multiPropArray).by([{ asci: 'name' }]))
-      .to.throw(Error);
+    .to.throw(Error);
 
     expect(() => sort(multiPropArray).by([{ asc: 'lastName' }, { ass: 'name' }]))
-      .to.throw(Error);
+    .to.throw(Error);
   });
 
   it('Should sort ascending with by on 1 property', () => {
@@ -199,14 +202,25 @@ describe('sort', () => {
     );
   });
 
-  it('Should sort using a collator', () => {
+  it('Should sort flat array using a comparer', () => {
     sort(flatNaturalArray).by([
-      { asc: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }) }
+      { asc: o=>o, comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare }
     ]);
 
     assertOrder(
       ['A1', 'A10', 'B2', 'B10'],
       idx => flatNaturalArray[idx],
+    );
+  });
+
+  it('Should sort object using a comparer', () => {
+    sort(persons).by([
+      { asc: p => p.unit, comparer: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }).compare }
+    ]);
+
+    assertOrder(
+      ['A1', 'A10', 'B10'],
+      idx => persons[idx].unit,
     );
   });
 });

--- a/test/unit/sort.spec.js
+++ b/test/unit/sort.spec.js
@@ -3,6 +3,7 @@ const sort = require('../../src/sort');
 
 describe('sort', () => {
   let flatArray;
+  let flatNaturalArray;
   let persons;
   let multiPropArray;
 
@@ -14,6 +15,7 @@ describe('sort', () => {
 
   beforeEach(() => {
     flatArray = [1, 5, 3, 2, 4, 5];
+    flatNaturalArray = ['A10', 'A1', 'B10', 'B2'];
 
     persons = [{
       name: 'last',
@@ -194,6 +196,17 @@ describe('sort', () => {
     assertOrder(
       [11, 10, 9, 8, 6],
       idx => multiPropArray[idx].age,
+    );
+  });
+
+  it('Should sort using a collator', () => {
+    sort(flatNaturalArray).by([
+      { asc: new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' }) }
+    ]);
+
+    assertOrder(
+      ['A1', 'A10', 'B2', 'B10'],
+      idx => flatNaturalArray[idx],
     );
   });
 });


### PR DESCRIPTION
Allows for natural sort (see usage in test), and preserves all current sorting methods in by().